### PR TITLE
ShapeType :idea: Only use the narrow type when there's only a single one for key and for value

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -488,7 +488,7 @@ TypePtr ArgInfo::argumentTypeAsSeenByImplementation(Context ctx, core::TypeConst
         return instantiated;
     }
     if (flags.isKeyword) {
-        return Types::hashOf(ctx, instantiated);
+        return Types::hashOfSymbolKey(ctx, instantiated);
     }
     return Types::arrayOf(ctx, instantiated);
 }

--- a/core/Types.h
+++ b/core/Types.h
@@ -159,7 +159,8 @@ public:
 
     static TypePtr arrayOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr rangeOf(const GlobalState &gs, const TypePtr &elem);
-    static TypePtr hashOf(const GlobalState &gs, const TypePtr &elem);
+    static TypePtr hashOfSymbolKey(const GlobalState &gs, const TypePtr &elem);
+    static TypePtr hashOf(const GlobalState &gs, const TypePtr &key, const TypePtr &elem);
     static TypePtr dropNil(const GlobalState &gs, const TypePtr &from);
 
     /** Recursively replaces proxies with their underlying types */

--- a/core/Types.h
+++ b/core/Types.h
@@ -157,7 +157,6 @@ public:
     /** Internal implementation. You should probably use any(). */
     static TypePtr lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
 
-    static TypePtr lubAll(const GlobalState &gs, const std::vector<TypePtr> &elements);
     static TypePtr arrayOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr rangeOf(const GlobalState &gs, const TypePtr &elem);
     static TypePtr hashOf(const GlobalState &gs, const TypePtr &elem);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2665,6 +2665,32 @@ optional<Loc> locOfValueForKey(const GlobalState &gs, const Loc origin, const Na
 
 } // namespace
 
+// TODO(jez) Add tests for this
+class Shape_squareBrackets : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        auto &shape = cast_type_nonnull<ShapeType>(args.thisType);
+
+        if (args.args.size() != 1) {
+            // Skip over cases for which arg matching should report errors
+            return;
+        }
+
+        if (!isa_type<LiteralType>(args.args.front()->type)) {
+            return;
+        }
+
+        auto argLit = cast_type_nonnull<LiteralType>(args.args.front()->type);
+        if (auto idx = indexForKey(shape, argLit)) {
+            res.returnType = shape.values[*idx];
+        } else {
+            // TODO(jez) This could be another "if you're in `typed: strict` you have to have better hashes"
+            res.returnType = Types::untypedUntracked();
+        }
+    }
+} Shape_squareBrackets;
+
+// TODO(jez) Add tests for this
 class Shape_squareBracketsEq : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
@@ -2712,8 +2738,8 @@ public:
             // Returning here without setting res.resultType will cause dispatchCall to fall back to
             // Hash#[]=, which will have the effect of checking the arg types.
             //
-            // TODO(jez) Right now ShapeType::underlying always returns T::Hash[T.untyped, T.untyped]
-            // so it doesn't matter whether we return or not.
+            // TODO(jez) We could do something smarter here, like check that the new value is
+            // compatible with the old value.
             return;
         } else {
             // Key not found. To preserve legacy compatibility, allow any arguments here.
@@ -3336,7 +3362,6 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::DeclBuilderForProcsSingleton(), Intrinsic::Kind::Instance, Names::params(), &DeclBuilderForProcs_params},
     {Symbols::DeclBuilderForProcsSingleton(), Intrinsic::Kind::Instance, Names::bind(), &DeclBuilderForProcs_bind},
 
-    // TODO(jez) Make or find an issue recording that we should also have Shape_squareBrackets
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::squareBrackets(), &Tuple_squareBrackets},
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::first(), &Tuple_first},
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::last(), &Tuple_last},
@@ -3345,6 +3370,7 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::toA(), &Tuple_to_a},
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::concat(), &Tuple_concat},
 
+    {Symbols::Shape(), Intrinsic::Kind::Instance, Names::squareBrackets(), &Shape_squareBrackets},
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::squareBracketsEq(), &Shape_squareBracketsEq},
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::merge(), &Shape_merge},
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::toHash(), &Shape_to_hash},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3336,6 +3336,7 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::DeclBuilderForProcsSingleton(), Intrinsic::Kind::Instance, Names::params(), &DeclBuilderForProcs_params},
     {Symbols::DeclBuilderForProcsSingleton(), Intrinsic::Kind::Instance, Names::bind(), &DeclBuilderForProcs_bind},
 
+    // TODO(jez) Make or find an issue recording that we should also have Shape_squareBrackets
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::squareBrackets(), &Tuple_squareBrackets},
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::first(), &Tuple_first},
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::last(), &Tuple_last},

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -276,14 +276,6 @@ TypePtr Types::dropLiteral(const GlobalState &gs, const TypePtr &tp) {
     return tp;
 }
 
-TypePtr Types::lubAll(const GlobalState &gs, const vector<TypePtr> &elements) {
-    TypePtr acc = Types::bottom();
-    for (auto &el : elements) {
-        acc = Types::lub(gs, acc, el);
-    }
-    return acc;
-}
-
 TypePtr Types::arrayOf(const GlobalState &gs, const TypePtr &elem) {
     vector<TypePtr> targs{move(elem)};
     return make_type<AppliedType>(Symbols::Array(), move(targs));
@@ -323,6 +315,15 @@ void sanityCheckProxyType(const GlobalState &gs, TypePtr underlying) {
     ENFORCE(isa_type<ClassType>(underlying) || isa_type<AppliedType>(underlying));
     underlying.sanityCheck(gs);
 }
+
+TypePtr lubAllDropLiteral(const GlobalState &gs, const vector<TypePtr> &elements) {
+    TypePtr acc = Types::bottom();
+    for (auto &el : elements) {
+        acc = Types::lub(gs, acc, Types::dropLiteral(gs, el));
+    }
+    return acc;
+}
+
 } // namespace
 
 LiteralType::LiteralType(int64_t val) : value(val), literalKind(LiteralTypeKind::Integer) {
@@ -418,14 +419,19 @@ ShapeType::ShapeType(vector<TypePtr> keys, vector<TypePtr> values) : keys(move(k
 }
 
 TypePtr ShapeType::underlying(const GlobalState &gs) const {
-    return Types::hashOfUntyped();
+    auto keysLub = lubAllDropLiteral(gs, this->keys);
+    auto valuesLub = lubAllDropLiteral(gs, this->values);
+    vector<TypePtr> tupleArgs{keysLub, valuesLub};
+    vector<TypePtr> targs{keysLub, valuesLub, make_type<TupleType>(move(tupleArgs))};
+    return make_type<AppliedType>(Symbols::Hash(), targs);
 }
 
 TypePtr TupleType::underlying(const GlobalState &gs) const {
     if (this->elems.empty()) {
         return Types::arrayOfUntyped();
     } else {
-        return Types::arrayOf(gs, Types::dropLiteral(gs, Types::lubAll(gs, this->elems)));
+        // TODO(jez) memoize?
+        return Types::arrayOf(gs, lubAllDropLiteral(gs, this->elems));
     }
 }
 

--- a/test/testdata/core/types/types_literal_hashes.rb
+++ b/test/testdata/core/types/types_literal_hashes.rb
@@ -1,0 +1,45 @@
+# typed: true
+extend T::Sig
+
+sig { params(x: T::Hash[Symbol, Numeric]).void }
+def foo(x); end
+
+sig { params(x: T::Hash[Symbol, T.nilable(Numeric)]).void }
+def bar(x); end
+
+class Baz; end
+
+sig { params(x: T::Hash[Symbol, T.nilable(Baz)]).void }
+def baz(x); end
+
+xi = {a: 1, b: 2}
+T.reveal_type(xi) # error: Revealed type: `{a: Integer(1), b: Integer(2)} (shape of T::Hash[Symbol, Integer])`
+foo(xi)
+bar(xi)
+
+xf = {a: 1.0, b: 2.0}
+T.reveal_type(xf) # error: Revealed type: `{a: Float(1.000000), b: Float(2.000000)} (shape of T::Hash[Symbol, Float])`
+foo(xf)
+bar(xf)
+
+xni = {a: 1, b: nil}
+T.reveal_type(xni) # error: Revealed type: `{a: Integer(1), b: NilClass} (shape of T::Hash[Symbol, T.nilable(Integer)])`
+bar(xni)
+foo(xni) # error: Expected `T::Hash[Symbol, Numeric]` but found `{a: Integer(1), b: NilClass}` for argument `x`
+
+xif = {a: 1, b: 2.0}
+T.reveal_type(xif) # error: Revealed type: `{a: Integer(1), b: Float(2.000000)} (shape of T::Hash[Symbol, T.untyped])`
+foo(xif)
+
+T.reveal_type({a: 1, "b" => 2}) # error: Revealed type: `{a: Integer(1), String("b") => Integer(2)} (shape of T::Hash[T.any(Symbol, String), Integer])`
+T.reveal_type({a: 1, "b" => 2.0}) # error: Revealed type: `{a: Integer(1), String("b") => Float(2.000000)} (shape of T::Hash[T.any(Symbol, String), T.untyped])`
+T.reveal_type({a: 1, "b" => 2.0, 3 => nil}) # error: Revealed type: `{a: Integer(1), String("b") => Float(2.000000), Integer(3) => NilClass} (shape of T::Hash[T.any(Symbol, String, Integer), T.untyped])`
+T.reveal_type({a: 1.0, "b" => 2.0, 3 => nil}) # error: Revealed type: `{a: Float(1.000000), String("b") => Float(2.000000), Integer(3) => NilClass} (shape of T::Hash[T.any(Symbol, String, Integer), T.nilable(Float)])`
+
+xz = {a: Baz.new, b: Baz.new}
+T.reveal_type(xz) # error: Revealed type: `{a: Baz, b: Baz} (shape of T::Hash[Symbol, Baz])`
+baz(xz)
+
+xnz = {a: nil, b: Baz.new}
+T.reveal_type(xnz) # error: Revealed type: `{a: NilClass, b: Baz} (shape of T::Hash[Symbol, T.nilable(Baz)])`
+baz(xnz)

--- a/test/testdata/infer/arg_matching.rb
+++ b/test/testdata/infer/arg_matching.rb
@@ -95,8 +95,10 @@ class TestArgs
   def call_mixed
     mixed(0, u: 1)
     mixed(0, 1, u: 1)
-    mixed(0, 1, {z: 1}, u: 1)
-    mixed(0, 1, {z: 1}, "hi", "there", u: 1, v: 0)
+    mixed(0, 1, {z: 1}, u: 1) # error: Expected `T::Hash[Integer, Integer]` but found `{z: Integer(1)}` for argument `z`
+    mixed(0, 1, {z: 1}, "hi", "there", u: 1, v: 0) # error: Expected `T::Hash[Integer, Integer]` but found `{z: Integer(1)}` for argument `z`
+    mixed(0, 1, {2 => 1}, u: 1)
+    mixed(0, 1, {2 => 1}, "hi", "there", u: 1, v: 0)
   end
 
   def optkw(x, y=T.unsafe(nil), u:)

--- a/test/testdata/infer/empty_shape_tuple_literal.rb
+++ b/test/testdata/infer/empty_shape_tuple_literal.rb
@@ -1,0 +1,48 @@
+# typed: strict
+
+extend T::Sig
+
+# We treat empty shapes and tuples as containers of untyped because it is so
+# common for people to mutate them, expanding their type.
+#
+# We could imagine a world where at `# typed: strict` users are required to
+# type their empty array and hash literals. But for now, we treat them as
+# containers of `T.untyped` implicitly
+
+sig {void}
+def shape_test1
+  T.reveal_type({}) # error: Revealed type: `{} (shape of T::Hash[T.untyped, T.untyped])`
+  T.reveal_type({}[:foo]) # error: Revealed type: `T.untyped`
+
+  {}.fetch(:foo)
+  puts 'should be reachable'
+end
+
+sig {void}
+def shape_test2
+  xs = {}
+  1.times do
+    xs[:foo] = 1
+  end
+
+  T.reveal_type(xs) # error: Revealed type: `{} (shape of T::Hash[T.untyped, T.untyped])`
+end
+
+sig {void}
+def tuple_test1
+  T.reveal_type([]) # error: Revealed type: `[] (0-tuple)`
+  T.reveal_type([][0]) # error: Revealed type: `NilClass`
+
+  [].fetch(0)
+  puts 'should be reachable'
+end
+
+sig {void}
+def tuple_test2
+  xs = []
+  1.times do
+    xs[0] = 1
+  end
+
+  T.reveal_type(xs) # error: Revealed type: `[] (0-tuple)`
+end

--- a/test/testdata/infer/shape_square_brackets.rb
+++ b/test/testdata/infer/shape_square_brackets.rb
@@ -2,6 +2,19 @@
 
 extend T::Sig
 
+def test1
+  x = {foo: 1}
+
+  T.reveal_type(x[:foo]) # error: Revealed type: `Integer(1)`
+
+  # This is untyped for backwards compatibility with the original shape implementation.
+  # We didn't want to introduce so many errors all at once, because the migration effort was huge.
+  T.reveal_type(x[:bar]) # error: Revealed type: `T.untyped`
+
+  # This doesn't raise an error either (String access, not Symbol access)
+  T.reveal_type(x['bar']) # error: Revealed type: `T.untyped`
+end
+
 sig {params(x: {foo: Integer}).void}
 def test2(x)
   x[:foo] = 1

--- a/test/testdata/infer/shape_to_hash.rb
+++ b/test/testdata/infer/shape_to_hash.rb
@@ -12,8 +12,8 @@ class A
 end
 
 foo = {x: "hello", y: 333, z: A.new}
-T.reveal_type(foo) # error: Revealed type: `{x: String("hello"), y: Integer(333), z: A} (shape of T::Hash[T.untyped, T.untyped])`
-T.reveal_type(foo.to_hash) # error: Revealed type: `{x: String("hello"), y: Integer(333), z: A} (shape of T::Hash[T.untyped, T.untyped])`
+T.reveal_type(foo) # error: Revealed type: `{x: String("hello"), y: Integer(333), z: A} (shape of T::Hash[Symbol, T.any(String, Integer, A)])`
+T.reveal_type(foo.to_hash) # error: Revealed type: `{x: String("hello"), y: Integer(333), z: A} (shape of T::Hash[Symbol, T.any(String, Integer, A)])`
 
 bar = {x: "yolo", y: 209, z: "hello again"}
 
@@ -23,8 +23,8 @@ else
   baz = bar
 end
 
-T.reveal_type(baz) # error: Revealed type: `{x: String, y: Integer, z: T.any(A, String)} (shape of T::Hash[T.untyped, T.untyped])`
-T.reveal_type(baz.to_hash) # error: Revealed type: `{x: String, y: Integer, z: T.any(A, String)} (shape of T::Hash[T.untyped, T.untyped])`
+T.reveal_type(baz) # error: Revealed type: `{x: String, y: Integer, z: T.any(A, String)} (shape of T::Hash[Symbol, T.any(A, String, Integer)])`
+T.reveal_type(baz.to_hash) # error: Revealed type: `{x: String, y: Integer, z: T.any(A, String)} (shape of T::Hash[Symbol, T.any(A, String, Integer)])`
 
 if T.unsafe(false)
   qux = baz

--- a/test/testdata/infer/shape_underlying.rb
+++ b/test/testdata/infer/shape_underlying.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+T.let({foo: 0}, T::Hash[String, Float]) # error: Argument does not have asserted type

--- a/test/testdata/infer/tuples.rb
+++ b/test/testdata/infer/tuples.rb
@@ -17,7 +17,7 @@ T.assert_type!([1, 2].first, Integer)
 T.assert_type!([1, 2].last, Integer)
 
 
-# Empty arrays are T::Array[T.untyped]
+# Empty arrays start as zero-tuples but decay to T::Array[T.untyped] (not T::Array[T.noreturn])
 empty = []
 T.assert_type!(empty, T::Array[T.untyped])
 T.assert_type!(empty[0], NilClass)

--- a/test/testdata/lsp/completion/sig_snippet.D.rbedited
+++ b/test/testdata/lsp/completion/sig_snippet.D.rbedited
@@ -38,7 +38,7 @@ def passes_array_untyped(xs)
   T.unsafe(nil)
 end
 
-sig {params(x: T::Hash[${1:T.untyped}, ${2:T.untyped}]).returns(${3:T.untyped})}${0} # error: no block
+sig {params(x: T::Hash[Symbol, String]).returns(${1:T.untyped})}${0} # error: no block
 #  ^ apply-completion: [D] item: 0
 def passes_shape(x)
   takes_shape(x)

--- a/test/testdata/lsp/hover_method_for_building_arrays_and_hashes.rb
+++ b/test/testdata/lsp/hover_method_for_building_arrays_and_hashes.rb
@@ -25,23 +25,23 @@ class Issue1777
   end
 
   def hash_hover
-    T.reveal_type({ # error: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
-      #           ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
+    T.reveal_type({ # error: {foo: String("foo"), bar: Integer(123)}
+      #           ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[Symbol, T.any(String, Integer)])
       # Test hovering over first item in array
       foo: "foo",
       #        ^ hover: String("foo")
       #         ^ hover: String("foo")
-      #          ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
+      #          ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[Symbol, T.any(String, Integer)])
 
       # Test hovering over comment
-      # ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
+      # ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[Symbol, T.any(String, Integer)])
 
       # Test hovering over last item in array
       bar: 123
       #      ^ hover: Integer(123)
       #       ^ hover: Integer(123)
-      #        ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
+      #        ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[Symbol, T.any(String, Integer)])
       })
-    # ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[T.untyped, T.untyped])
+    # ^ hover: {foo: String("foo"), bar: Integer(123)} (shape of T::Hash[Symbol, T.any(String, Integer)])
   end
 end

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -81,7 +81,7 @@ class MyTest
 
   test_each ["foo", 5, {x: false}] do |v|
     it "handles lists with several types" do
-      T.reveal_type(v) # error: Revealed type: `T.any(String, Integer, T::Hash[T.untyped, T.untyped])`
+      T.reveal_type(v) # error: Revealed type: `T.any(String, Integer, T::Hash[Symbol, FalseClass])`
     end
   end
 
@@ -98,10 +98,8 @@ class MyTest
 
   test_each_hash({foo: 1, bar: 2, baz: 3}) do |k, v|
     it "handles lists with several types" do
-      # we don't decay literal hash types like we do for arrays, so
-      # these will still be untyped here
-      T.reveal_type(k) # error: Revealed type: `T.untyped`
-      T.reveal_type(v) # error: Revealed type: `T.untyped`
+      T.reveal_type(k) # error: Revealed type: `Symbol`
+      T.reveal_type(v) # error: Revealed type: `Integer`
     end
   end
 


### PR DESCRIPTION
Always use inferred Hash key type. Use inferred value type when single-valued, otherwise untyped
Allow T.nilable(ClassType) value to be inferred as literal hash value type
Tests for inferring types of literal Hash'es

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
